### PR TITLE
More detailed error handling from the API

### DIFF
--- a/src/components/ErrorFallback/ErrorFallback.tsx
+++ b/src/components/ErrorFallback/ErrorFallback.tsx
@@ -1,5 +1,3 @@
-import get from "lodash/get";
-import { Stack } from "@deskpro/deskpro-ui";
 import { DEFAULT_ERROR } from "../../constants";
 import { ShopifyError } from "../../services/shopify";
 import { Container, ErrorBlock } from "../common";
@@ -11,25 +9,26 @@ type Props = Omit<FallbackProps, "error"> & {
 };
 
 const ErrorFallback: FC<Props> = ({ error }) => {
-  let message = DEFAULT_ERROR;
+  let message: string|string[] = DEFAULT_ERROR;
 
   // eslint-disable-next-line no-console
   console.error(error);
 
   if (error instanceof ShopifyError) {
-    message = get(error, ["data", "errors"])
-      || DEFAULT_ERROR;
+    let arrayOfErrors: string[] = [];
+
+    if (Array.isArray(error.data?.errors)) {
+      arrayOfErrors = error.data?.errors
+        .map((e) => (typeof e === "string") ? e : e.message)
+        .filter(Boolean);
+    }
+
+    message = arrayOfErrors.length > 0 ? arrayOfErrors : DEFAULT_ERROR;
   }
 
   return (
     <Container>
-      <ErrorBlock
-        text={(
-          <Stack gap={6} vertical style={{ padding: "8px" }}>
-            {message}
-          </Stack>
-        )}
-      />
+      <ErrorBlock text={message}/>
     </Container>
   );
 };

--- a/src/components/common/Error/ErrorBlock.tsx
+++ b/src/components/common/Error/ErrorBlock.tsx
@@ -1,21 +1,28 @@
 import styled from "styled-components";
 import { P5 } from "@deskpro/deskpro-ui";
-import type { FC, JSX } from "react";
-import type { Maybe } from "../../../types";
+import { DEFAULT_ERROR } from "../../../constants";
+import type { FC, ReactNode } from "react";
 
 type Props = {
-  text?: Maybe<string|JSX.Element|Array<string|JSX.Element>>,
+  text?: ReactNode;
 }
 
 const StyledErrorBlock = styled(P5)`
+  width: 100%;
   margin-bottom: 8px;
   padding: 4px 6px;
   border-radius: 4px;
   color: ${({ theme }) => theme.colors.white};
   background-color: ${({ theme }) => theme.colors.red100};
+  box-sizing: border-box;
+  overflow-wrap: break-word;
+  word-wrap: break-word;
+  white-space: normal;
+  overflow: hidden;
+  text-overflow: ellipsis;
 `;
 
-const ErrorBlock: FC<Props> = ({ text = "An error occurred" }) => (
+const ErrorBlock: FC<Props> = ({ text = DEFAULT_ERROR }) => (
   <>
     {Array.isArray(text)
       ? text.map((msg, idx) => (<StyledErrorBlock key={idx}>{msg}</StyledErrorBlock>))

--- a/src/services/shopify/types.ts
+++ b/src/services/shopify/types.ts
@@ -1,7 +1,7 @@
 export type Response<T> = Promise<{ data: T }>;
 
 export type ShopifyGraphQLError = {
-  errors: string,
+  errors: string|Array<{ message: string }>,
 };
 
 export type CustomerSearchParams = {


### PR DESCRIPTION
Story https://app.shortcut.com/deskpro/story/166062/shopify-app-us-version-returns-blank-search-results

We just didn’t show the error message that returned the API. I implemented more detailed error handling.

![image](https://github.com/user-attachments/assets/8a6b687d-b570-4051-bca6-e4a43925fffe)
